### PR TITLE
Update max value for LED Strip Effect to allow for 5 effects

### DIFF
--- a/config/inovelli/lzw31-sn.xml
+++ b/config/inovelli/lzw31-sn.xml
@@ -155,10 +155,10 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     <Item value="9" label="90%"/>
     <Item value="10" label="100%"/>
     </Value>
-	<Value genre="config" type="int" size="4" index="16" label="LED Strip Effect" min="0" max="83823359" value="0">
+	<Value genre="config" type="int" size="4" index="16" label="LED Strip Effect" min="0" max="100600575" value="0">
       <Help>
       Please see website for documentation.
-      Range: 0-83823359
+      Range: 0-100600575
       Default: 0
       </Help>
     </Value>


### PR DESCRIPTION
Currently the max value is set to 83823359 which will only get you 4 levels of effects.  This will set that max to 100600575 which will allow for the 5th effect.